### PR TITLE
Fix buffer scope issue and apply optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,8 @@ name = "devdocs"
 [dependencies]
 html2text = "0.12.5"
 nvim-oxi = { version = "0.5.1",  features = ["neovim-0-10"]}
+
+[profile.release]
+lto = true
+strip = "symbols"
+opt-level = "z"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ fn devdocs() -> nvim_oxi::Result<Dictionary> {
     use std::cell::RefCell;
     use std::rc::Rc;
 
-    //I think I need to do the same thing for buf
     let win: Rc<RefCell<Option<Window>>> = Rc::default();
     let w = Rc::clone(&win);
 
@@ -41,7 +40,7 @@ fn devdocs() -> nvim_oxi::Result<Dictionary> {
         win.close(false)
     };
 
-    let close_keymap = |b: &Buffer| -> Result<(), api::Error> {
+    let close_keymap = |b: &mut Buffer| -> Result<(), api::Error> {
         let opts = SetKeymapOpts::builder()
             .desc("Closes the Devdocs window")
             .callback(close_window.clone())  // Clone the closure for reuse
@@ -52,10 +51,11 @@ fn devdocs() -> nvim_oxi::Result<Dictionary> {
         // Set both keymaps inside the same function to ensure the buffer reference stays in scope.
         api::Buffer::set_keymap(b, Mode::Normal, "q", "", &opts)?;
         api::Buffer::set_keymap(b, Mode::Normal, "<Esc>", "", &opts)?;
+
         Ok(())
     };
 
-    close_keymap(&buf).ok();
+    close_keymap(&mut buf).ok();
     ////////////////////////////////////////////
 
     let window = move |_| -> Result<(), api::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,21 +41,21 @@ fn devdocs() -> nvim_oxi::Result<Dictionary> {
         win.close(false)
     };
 
-    let close_keymap = |b: &mut Buffer| -> Result<(), api::Error> {
+    let close_keymap = |b: &Buffer| -> Result<(), api::Error> {
         let opts = SetKeymapOpts::builder()
             .desc("Closes the Devdocs window")
-            .callback(close_window)
+            .callback(close_window.clone())  // Clone the closure for reuse
             .nowait(true)
             .silent(true)
             .build();
 
-        //FIXME: This is not working. second line can't set a keymap because b goes out of scope.
+        // Set both keymaps inside the same function to ensure the buffer reference stays in scope.
         api::Buffer::set_keymap(b, Mode::Normal, "q", "", &opts)?;
         api::Buffer::set_keymap(b, Mode::Normal, "<Esc>", "", &opts)?;
         Ok(())
     };
 
-    close_keymap(&mut buf).ok();
+    close_keymap(&buf).ok();
     ////////////////////////////////////////////
 
     let window = move |_| -> Result<(), api::Error> {


### PR DESCRIPTION
Fix buffer scope issue and apply optimizations

- Fixed buffer keymap scope issue to prevent early drop
- Enabled release optimizations for smaller binary size
- Added Link-Time Optimization (LTO) and size-specific optimization (`opt-level = "z"`)